### PR TITLE
Integrate initial DHT Sensor code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,107 @@
+# See: https://releases.llvm.org/11.1.0/tools/clang/docs/ClangFormatStyleOptions.html
+Language: Cpp
+Standard: c++17
+TabWidth: 4
+IndentWidth: 4
+UseTab: Never
+ColumnLimit: 175
+BasedOnStyle: WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: DontAlign
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: false
+CompactNamespaces: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+FixNamespaceComments: true
+IncludeBlocks: Regroup
+IncludeCategories:
+  # Headers in <> without extension.
+  - Regex: '<([A-Za-z0-9\/_-])+>'
+    Priority: 4
+  # Headers in <> from specific external libraries.
+  - Regex: '^<|"(gtest|gmock|boost|ros|industrial_msgs|simple_message)\/'
+    Priority: 3
+  # Headers in <> with extension.
+  - Regex: '<([A-Za-z0-9.\/_-])+>'
+    Priority: 2
+  # Headers in "" with extension.
+  - Regex: '"([A-Za-z0-9.\/_-])+"'
+    Priority: 1
+IndentCaseLabels: false
+IndentPPDirectives: AfterHash
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,155 @@
+---
+Checks:          'clang-diagnostic-*,-clang-diagnostic-c++17-extensions,clang-analyzer-*,performance-*,readability-*,-readability-redundant-member-init,-readability-use-anyofallof,-readability-convert-member-functions-to-static,-readability-redundant-access-specifiers,bugprone-*,cert-*,boost-use-to-string,google-runtime-init,hicpp-exception-baseclass,hicpp-multiway-paths-covered,hicpp-signed-bitwise,misc-misplaced-const,misc-static-assert,misc-unused-using-decls'
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:             bugprone-argument-comment.StrictMode
+    value:           '0'
+  - key:             bugprone-assert-side-effect.AssertMacros
+    value:           assert
+  - key:             bugprone-assert-side-effect.CheckFunctionCalls
+    value:           '0'
+  - key:             bugprone-dangling-handle.HandleClasses
+    value:           'std::basic_string_view;std::experimental::basic_string_view'
+  - key:             bugprone-exception-escape.FunctionsThatShouldNotThrow
+    value:           ''
+  - key:             bugprone-exception-escape.IgnoredExceptions
+    value:           ''
+  - key:             bugprone-misplaced-widening-cast.CheckImplicitCasts
+    value:           '0'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant
+    value:           '1'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfConstant
+    value:           '1'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression
+    value:           '0'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfThis
+    value:           '1'
+  - key:             bugprone-string-constructor.LargeLengthThreshold
+    value:           '8388608'
+  - key:             bugprone-string-constructor.WarnOnLargeLength
+    value:           '1'
+  - key:             bugprone-suspicious-enum-usage.StrictMode
+    value:           '0'
+  - key:             bugprone-suspicious-missing-comma.MaxConcatenatedTokens
+    value:           '5'
+  - key:             bugprone-suspicious-missing-comma.RatioThreshold
+    value:           '0.200000'
+  - key:             bugprone-suspicious-missing-comma.SizeThreshold
+    value:           '5'
+  - key:             bugprone-suspicious-string-compare.StringCompareLikeFunctions
+    value:           ''
+  - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison
+    value:           '1'
+  - key:             bugprone-suspicious-string-compare.WarnOnLogicalNotComparison
+    value:           '0'
+  - key:             bugprone-unused-return-value.CheckedFunctions
+    value:           '::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty'
+  - key:             cert-dcl16-c.IgnoreMacros
+    value:           '1'
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-dcl59-cpp.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             cert-err09-cpp.CheckThrowTemporaries
+    value:           '1'
+  - key:             cert-err61-cpp.CheckThrowTemporaries
+    value:           '1'
+  - key:             cert-msc32-c.DisallowedSeedTypes
+    value:           'time_t,std::time_t'
+  - key:             cert-msc51-cpp.DisallowedSeedTypes
+    value:           'time_t,std::time_t'
+  - key:             cert-oop11-cpp.IncludeStyle
+    value:           llvm
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             hicpp-multiway-paths-covered.WarnOnMissingElse
+    value:           '0'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             performance-faster-string-find.StringLikeClasses
+    value:           'std::basic_string'
+  - key:             performance-for-range-copy.AllowedTypes
+    value:           ''
+  - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           '0'
+  - key:             performance-inefficient-string-concatenation.StrictMode
+    value:           '0'
+  - key:             performance-inefficient-vector-operation.VectorLikeClasses
+    value:           '::std::vector'
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           '1'
+  - key:             performance-move-constructor-init.IncludeStyle
+    value:           llvm
+  - key:             performance-type-promotion-in-math-fn.IncludeStyle
+    value:           llvm
+  - key:             performance-unnecessary-copy-initialization.AllowedTypes
+    value:           ''
+  - key:             performance-unnecessary-value-param.AllowedTypes
+    value:           ''
+  - key:             performance-unnecessary-value-param.IncludeStyle
+    value:           llvm
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '0'
+  - key:             readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             readability-function-size.VariableThreshold
+    value:           '4294967295'
+  - key:             readability-identifier-naming.IgnoreFailedSplit
+    value:           '0'
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           '0'
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           '1'
+  - key:             readability-inconsistent-declaration-parameter-name.IgnoreMacros
+    value:           '1'
+  - key:             readability-inconsistent-declaration-parameter-name.Strict
+    value:           '0'
+  - key:             readability-magic-numbers.IgnoredFloatingPointValues
+    value:           '1.0;100.0;'
+  - key:             readability-magic-numbers.IgnoredIntegerValues
+    value:           '1;2;3;4;'
+  - key:             readability-redundant-smartptr-get.IgnoreMacros
+    value:           '1'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value:           '0'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
+    value:           '0'
+  - key:             readability-simplify-subscript-expr.Types
+    value:           '::std::basic_string;::std::basic_string_view;::std::vector;::std::array'
+  - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
+    value:           '3'
+  - key:             readability-uppercase-literal-suffix.IgnoreMacros
+    value:           '1'
+  - key:             readability-uppercase-literal-suffix.NewSuffixes
+    value:           ''
+  - key:             hicpp-signed-bitwise.IgnorePositiveIntegerLiterals
+    value:           true
+...

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,6 +4,7 @@
             "name": "Linux",
             "includePath": [
                 "/usr/include/newlib/c++/10.3.1",
+                "/etc/pico-sdk/src/boards/include/**",
                 "/etc/pico-sdk/src/common/pico_base/include/**",
                 "/etc/pico-sdk/src/common/pico_stdlib/include/**",
                 "/etc/pico-sdk/src/common/pico_time/include/**",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "cSpell.words": [
         "Pico",
         "Porembski",
+        "RASPBERRYPI",
         "SSID"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,12 @@
     "files.associations": {
         "*.impl": "cpp",
         "string_view": "cpp",
-        "array": "cpp"
+        "array": "cpp",
+        "chrono": "cpp"
     },
     "cSpell.words": [
         "Pico",
+        "Porembski",
         "SSID"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
     "files.associations": {
         "*.impl": "cpp",
-        "string_view": "cpp"
+        "string_view": "cpp",
+        "array": "cpp"
     },
     "cSpell.words": [
         "Pico",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# cmake-format: off
 cmake_minimum_required(VERSION 3.17.0)
 
 # Must setup the PICO SDK before the project macro call
@@ -46,3 +47,4 @@ target_sources(${PROJECT_NAME} PRIVATE src/main.cpp)
 target_link_libraries(${PROJECT_NAME} pico_stdlib hardware_i2c)
 
 pico_add_extra_outputs(${PROJECT_NAME})
+# cmake-format: on

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,16 +7,16 @@ project(environment-monitor C CXX ASM)
 string(TIMESTAMP BUILD_TIME "%s")
 
 if(NOT DEFINED BUILD_VERSION)
-    set(BUILD_VERSION "0.0.0+${BUILD_TIME}")
+  set(BUILD_VERSION "0.0.0+${BUILD_TIME}")
 endif()
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(CMAKE_BUILD_TYPE Release)
+  set(CMAKE_BUILD_TYPE Release)
 endif()
 
-###################
-## CONFIGURATION ##
-###################
+# ##############################################################################
+# CONFIGURATION ##
+# ##############################################################################
 
 initialize_pico()
 
@@ -24,41 +24,25 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/generated/configuration.hpp.in
-    ${CMAKE_BINARY_DIR}/generated/configuration.hpp
-    @ONLY
-)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/generated/configuration.hpp.in
+               ${CMAKE_BINARY_DIR}/generated/configuration.hpp @ONLY)
 
-#############
-##  BUILD  ##
-#############
+# ##############################################################################
+# BUILD  ##
+# ##############################################################################
 
 add_executable(${PROJECT_NAME})
 
 target_compile_options(
-    ${PROJECT_NAME}
-    PRIVATE
-        -Wall -Werror -Wno-format -Wno-unused-function -Wno-maybe-uninitialized
-)
+  ${PROJECT_NAME} PRIVATE -Wall -Werror -Wno-format -Wno-unused-function
+                          -Wno-maybe-uninitialized)
 
 target_include_directories(
-    ${PROJECT_NAME}
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
-        ${CMAKE_CURRENT_SOURCE_DIR}/build
-)
+  ${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
+                          ${CMAKE_CURRENT_SOURCE_DIR}/build)
 
-target_sources(
-    ${PROJECT_NAME}
-    PRIVATE
-        src/main.cpp
-)
+target_sources(${PROJECT_NAME} PRIVATE src/main.cpp)
 
-target_link_libraries(
-    ${PROJECT_NAME}
-    pico_stdlib
-    hardware_i2c
-)
+target_link_libraries(${PROJECT_NAME} pico_stdlib hardware_i2c)
 
 pico_add_extra_outputs(${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,16 +8,16 @@ project(environment-monitor C CXX ASM)
 string(TIMESTAMP BUILD_TIME "%s")
 
 if(NOT DEFINED BUILD_VERSION)
-  set(BUILD_VERSION "0.0.0+${BUILD_TIME}")
+    set(BUILD_VERSION "0.0.0+${BUILD_TIME}")
 endif()
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
-  set(CMAKE_BUILD_TYPE Release)
+    set(CMAKE_BUILD_TYPE Release)
 endif()
 
-# ##############################################################################
-# CONFIGURATION ##
-# ##############################################################################
+###################
+## CONFIGURATION ##
+###################
 
 initialize_pico()
 
@@ -25,26 +25,45 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/generated/configuration.hpp.in
-               ${CMAKE_BINARY_DIR}/generated/configuration.hpp @ONLY)
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/generated/configuration.hpp.in
+    ${CMAKE_BINARY_DIR}/generated/configuration.hpp
+    @ONLY
+)
 
-# ##############################################################################
-# BUILD  ##
-# ##############################################################################
+#############
+##  BUILD  ##
+#############
 
 add_executable(${PROJECT_NAME})
 
 target_compile_options(
-  ${PROJECT_NAME} PRIVATE -Wall -Werror -Wno-format -Wno-unused-function
-                          -Wno-maybe-uninitialized)
+    ${PROJECT_NAME}
+    PRIVATE
+        -Wall -Werror -Wno-format -Wno-unused-function -Wno-maybe-uninitialized
+)
 
 target_include_directories(
-  ${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
-                          ${CMAKE_CURRENT_SOURCE_DIR}/build)
+    ${PROJECT_NAME}
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/build
+)
 
-target_sources(${PROJECT_NAME} PRIVATE src/main.cpp)
+target_sources(
+    ${PROJECT_NAME}
+    PRIVATE
+        src/sensors/dht.cpp
 
-target_link_libraries(${PROJECT_NAME} pico_stdlib hardware_i2c)
+        src/main.cpp
+        src/utilities.cpp
+)
+
+target_link_libraries(
+    ${PROJECT_NAME}
+    pico_stdlib
+    hardware_i2c
+)
 
 pico_add_extra_outputs(${PROJECT_NAME})
 # cmake-format: on

--- a/cmake/pico-sdk.cmake
+++ b/cmake/pico-sdk.cmake
@@ -1,24 +1,24 @@
+# cmake-format: off
 set(PICO_BOARD pico_w)
 
 if(NOT DEFINED PICO_SDK_PATH)
-  if(DEFINED ENV{PICO_SDK_PATH})
-    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
-    message(STATUS "Using PICO_SDK_PATH from the environment: "
-                   ${PICO_SDK_PATH})
-  else()
-    message(FATAL_ERROR "PICO_SDK_PATH is not defined")
-    return()
-  endif()
+    if(DEFINED ENV{PICO_SDK_PATH})
+        set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+        message(STATUS "Using PICO_SDK_PATH from the environment: " ${PICO_SDK_PATH})
+    else()
+        message(FATAL_ERROR "PICO_SDK_PATH is not defined")
+        return()
+    endif()
 endif()
 
 include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
 
 macro(initialize_pico)
-  pico_sdk_init()
-
-  if(NOT PICO_CYW43_SUPPORTED)
-    message(
-      FATAL_ERROR "PICO W is not set as the target or not supported by the SDK")
-    return()
-  endif()
+    pico_sdk_init()
+    
+    if (NOT PICO_CYW43_SUPPORTED)
+        message(FATAL_ERROR "PICO W is not set as the target or not supported by the SDK")
+        return()
+    endif()
 endmacro()
+# cmake-format: on

--- a/cmake/pico-sdk.cmake
+++ b/cmake/pico-sdk.cmake
@@ -1,22 +1,24 @@
 set(PICO_BOARD pico_w)
 
 if(NOT DEFINED PICO_SDK_PATH)
-    if(DEFINED ENV{PICO_SDK_PATH})
-        set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
-        message(STATUS "Using PICO_SDK_PATH from the environment: " ${PICO_SDK_PATH})
-    else()
-        message(FATAL_ERROR "PICO_SDK_PATH is not defined")
-        return()
-    endif()
+  if(DEFINED ENV{PICO_SDK_PATH})
+    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    message(STATUS "Using PICO_SDK_PATH from the environment: "
+                   ${PICO_SDK_PATH})
+  else()
+    message(FATAL_ERROR "PICO_SDK_PATH is not defined")
+    return()
+  endif()
 endif()
 
 include(${PICO_SDK_PATH}/external/pico_sdk_import.cmake)
 
 macro(initialize_pico)
-    pico_sdk_init()
+  pico_sdk_init()
 
-    if (NOT PICO_CYW43_SUPPORTED)
-        message(FATAL_ERROR "PICO W is not set as the target or not supported by the SDK")
-        return()
-    endif()
+  if(NOT PICO_CYW43_SUPPORTED)
+    message(
+      FATAL_ERROR "PICO W is not set as the target or not supported by the SDK")
+    return()
+  endif()
 endmacro()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,12 +3,26 @@ Copyright 2023 Joe Porembski
 SPDX-License-Identifier: BSD-3-Clause
 ------------------------------------------------------------------------------*/
 #include "generated/configuration.hpp"
+#include "sensors/constants.hpp"
 #include "sensors/dht.hpp"
 
+#include <boards/pico_w.h>
+#include <hardware/gpio.h>
 #include <pico/stdlib.h>
+
+#include <cstdint>
+
+#ifdef RASPBERRYPI_PICO_W
+inline constexpr uint8_t LED_PIN = UINT8_MAX;
+#else
+inline constexpr uint8_t LED_PIN = PICO_DEFAULT_LED_PIN;
+#endif
+
+inline constexpr uint8_t DHT_DATA_PIN = 22;
 
 
 int main(int argc, char** argv)
 {
+    DHT sensor(DHTType::DHT22, DHT_DATA_PIN, LED_PIN);
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@ Copyright 2023 Joe Porembski
 SPDX-License-Identifier: BSD-3-Clause
 ------------------------------------------------------------------------------*/
 #include "generated/configuration.hpp"
+#include "sensors/dht.hpp"
 
 #include <pico/stdlib.h>
 

--- a/src/sensors/constants.hpp
+++ b/src/sensors/constants.hpp
@@ -1,0 +1,42 @@
+/*------------------------------------------------------------------------------
+Copyright 2023 Joe Porembski
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+------------------------------------------------------------------------------*/
+
+#include <cfloat>
+#include <chrono>
+#include <climits>
+#include <cstdint>
+
+
+inline constexpr float DEFAULT_HUMIDITY = FLT_MIN;
+inline constexpr float DEFAULT_TEMPERATURE = FLT_MIN;
+inline constexpr uint32_t ON = 1;
+inline constexpr uint32_t OFF = 0;
+inline constexpr uint32_t HIGH = ON;
+inline constexpr uint32_t LOW = OFF;
+inline constexpr uint32_t BITS_IN_BYTE = (sizeof(uint8_t) * CHAR_BIT);

--- a/src/sensors/constants.hpp
+++ b/src/sensors/constants.hpp
@@ -1,30 +1,6 @@
 /*------------------------------------------------------------------------------
 Copyright 2023 Joe Porembski
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+SPDX-License-Identifier: BSD-3-Clause
 ------------------------------------------------------------------------------*/
 
 #include <cfloat>

--- a/src/sensors/dht.cpp
+++ b/src/sensors/dht.cpp
@@ -1,0 +1,174 @@
+/*------------------------------------------------------------------------------
+Copyright 2023 Joe Porembski
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+------------------------------------------------------------------------------*/
+
+#include "sensors/dht.hpp"
+
+#include "sensors/constants.hpp"
+
+#include <hardware/gpio.h>
+#include <pico/stdio.h>
+#include <pico/stdlib.h>
+
+#include <array>
+#include <cfloat>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <thread>
+
+inline constexpr size_t BUFFER_SIZE = 5;
+inline constexpr size_t HUMIDITY_MSB_INDEX = 0;
+inline constexpr size_t HUMIDITY_LSB_INDEX = 1;
+inline constexpr size_t TEMP_MSB_INDEX = 2;
+inline constexpr size_t TEMP_LSB_INDEX = 3;
+inline constexpr size_t PARITY_INDEX = 4;
+inline constexpr float DATA_FACTOR = 10.0;
+inline constexpr uint8_t MAX_READ_CHECKS = 100;
+
+static uint8_t readByte(uint8_t pin)
+{}
+
+DHT::DHT(DHTType type, uint8_t data_pin, uint8_t feedback_led_pin)
+    : _humidity(DEFAULT_HUMIDITY), _temperature(DEFAULT_TEMPERATURE), _type(type), _data_pin(data_pin), _feedback_led_pin(feedback_led_pin)
+{
+    if (_feedback_led_pin < NUM_BANK0_GPIOS) {
+        gpio_init(_feedback_led_pin);
+        gpio_set_dir(_feedback_led_pin, GPIO_OUT);
+        gpio_put(_feedback_led_pin, LOW);
+    }
+}
+
+float DHT::humidity() const
+{
+    return _humidity;
+}
+
+float DHT::temperature() const
+{
+    return _temperature;
+}
+
+DHTType DHT::type() const
+{
+    return _type;
+}
+
+bool DHT::_check() const
+{
+    // The check behavior here is taken from Step 2 in DHT communication
+    // It is looking to verify the sensor response signal.
+    //
+    // Reference: https://www.waveshare.com/wiki/DHT22_Temperature-Humidity_Sensor
+    uint8_t read_count = 0;
+    gpio_set_dir(_data_pin, GPIO_IN);
+    while (gpio_get(_data_pin) && read_count < 100) {
+        read_count++;
+        sleep_us(1);
+    }
+
+    if (read_count >= MAX_READ_CHECKS) {
+        return false;
+    }
+
+    read_count = 0;
+    while (!gpio_get(_data_pin) && read_count < 100) {
+        read_count++;
+        sleep_us(1);
+    }
+
+    return read_count < MAX_READ_CHECKS;
+}
+
+void DHT::_read()
+{
+    std::array<uint8_t, BUFFER_SIZE> buffer;
+
+    _setLED(ON);
+    _reset();
+
+    if (!_check()) {
+        _setLED(OFF);
+        _temperature = DEFAULT_TEMPERATURE;
+        _humidity = DEFAULT_HUMIDITY;
+        printf("DHT Sensor did not respond to reset\n");
+        return;
+    }
+
+    for (size_t index; index < buffer.size(); index++) {
+        buffer[index] = readByte(_data_pin);
+    }
+
+    uint8_t calculated_parity = buffer[HUMIDITY_MSB_INDEX] + buffer[HUMIDITY_LSB_INDEX] + buffer[TEMP_MSB_INDEX] + buffer[TEMP_LSB_INDEX];
+    if (calculated_parity != buffer[PARITY_INDEX]) {
+        printf("DHT data parity check failed (%u != %u)\n", calculated_parity, buffer[PARITY_INDEX]);
+        _setLED(OFF);
+        return;
+    }
+
+    _setLED(OFF);
+
+    _humidity = ((buffer[HUMIDITY_MSB_INDEX] << BITS_IN_BYTE) + buffer[HUMIDITY_LSB_INDEX]) / DATA_FACTOR;
+    _temperature = (((buffer[TEMP_MSB_INDEX] & 0x7F) << BITS_IN_BYTE) + buffer[TEMP_LSB_INDEX]) / DATA_FACTOR;
+
+    if (_humidity > 100) {
+        _humidity = buffer[HUMIDITY_MSB_INDEX];
+    }
+
+    if (_temperature > 125) {
+        _temperature = buffer[TEMP_MSB_INDEX];
+    }
+
+    if (buffer[TEMP_MSB_INDEX] & 0x80) {
+        _temperature = -1 * _temperature;
+    }
+}
+
+void DHT::_reset()
+{
+    // The reset behavior here is taken from Step 2 in DHT communication
+    // Although some of the reference integration code provided by Waveshare show holding the data line low for longer.
+    // Basic flow here is to pull down the data line for 20 milliseconds then high for 20 microseconds.
+    //
+    // Reference: https://www.waveshare.com/wiki/DHT22_Temperature-Humidity_Sensor
+    gpio_set_dir(_data_pin, GPIO_OUT);
+    gpio_put(_data_pin, LOW);
+    sleep_ms(20);
+    gpio_put(_data_pin, HIGH);
+    sleep_us(20);
+    gpio_set_dir(_data_pin, GPIO_IN);
+}
+
+void DHT::_setLED(uint8_t state) const
+{
+    if (_feedback_led_pin >= NUM_BANK0_GPIOS) {
+        return;
+    }
+
+    gpio_put(_feedback_led_pin, state);
+}

--- a/src/sensors/dht.hpp
+++ b/src/sensors/dht.hpp
@@ -1,0 +1,61 @@
+/*------------------------------------------------------------------------------
+Copyright 2023 Joe Porembski
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+------------------------------------------------------------------------------*/
+#pragma once
+
+
+#include <cstdint>
+
+enum class DHTType : uint8_t
+{
+    DHT11,
+    DHT21,
+    DHT22
+};
+
+class DHT
+{
+public:
+    DHT(DHTType type, uint8_t data_pin, uint8_t feedback_led_pin);
+
+    float humidity() const;
+    float temperature() const;
+    DHTType type() const;
+
+private:
+    bool _check() const;
+    void _read();
+    void _reset();
+    void _setLED(uint8_t state) const;
+
+    float _humidity;
+    float _temperature;
+    DHTType _type;
+    uint8_t _data_pin;
+    uint8_t _feedback_led_pin;
+};

--- a/src/sensors/dht.hpp
+++ b/src/sensors/dht.hpp
@@ -5,37 +5,105 @@ SPDX-License-Identifier: BSD-3-Clause
 #pragma once
 
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 
+/**
+ * Enumerates the types of DHT sensors supported.
+ */
 enum class DHTType : uint8_t
 {
+    /** DHT 11 type sensor. */
     DHT11,
+
+    /** DHT 21 type sensor. */
     DHT21,
+
+    /** DHT 22 type sensor. */
     DHT22
 };
 
+/**
+ * An implementation of the DHT sensor compatible with the Raspberry Pi Pico.
+ *
+ * @note See https://www.waveshare.com/wiki/DHT22_Temperature-Humidity_Sensor
+ */
 class DHT
 {
 public:
+    static constexpr size_t FRAME_SIZE = 5;
+
+    using Frame = std::array<uint8_t, FRAME_SIZE>;
+
+    /**
+     * Constructor.
+     *
+     * @param[in] type The type of sensor.
+     * @param[in] data_pin The data pin of the DHT sensor.
+     * @param[in] feedback_led_pin The pin of the LED to toggle on/off. If provided, the LED will be on when data is being read from the sensor, and off otherwise.
+     */
     DHT(DHTType type, uint8_t data_pin, uint8_t feedback_led_pin);
 
+    /**
+     * @return The measured humidity as a percentage.
+     */
     float humidity() const;
+
+    /**
+     * @return The measured temperature in degrees Celsius.
+     */
     float temperature() const;
+
+    /**
+     * @return The type of DHT sensor.
+     */
     DHTType type() const;
 
 private:
+    /**
+     * Checks for the sensor's response indicating it is ready to be read from.
+     *
+     * @return true if the sensor is ready, false otherwise.
+     */
     bool _checkResponse() const;
 
     /**
      * Reads a bit from the sensor's data pin according to the protocol used by DHT sensors.
      *
-     * @note See https://www.waveshare.com/wiki/DHT22_Temperature-Humidity_Sensor
      * @return true if the bit is high, false if the bit is low.
      */
     bool _getDataBit() const;
+
+    /**
+     * Reads a byte from the sensor's data pin according to the protocol used by DHT sensors.
+     *
+     * @return The byte read from the sensor.
+     */
     uint8_t _getDataByte() const;
+
+    /**
+     * Parses the provided frame into a humidity and temperate.
+     *
+     * @param[in] data The data frame read from the sensor
+     */
+    void _parse(const Frame& data);
+
+    /**
+     * Reads data from the sensor.
+     */
     void _read();
+
+    /**
+     * Sets the LED to the value indicated by @a state.
+     *
+     * @param[in] state The desired state of the LED.
+     */
     void _setLED(uint8_t state) const;
+
+    /**
+     * Starts the process of reading a data frame from the sensor.
+     */
     void _start();
 
     float _humidity;

--- a/src/sensors/dht.hpp
+++ b/src/sensors/dht.hpp
@@ -1,30 +1,6 @@
 /*------------------------------------------------------------------------------
 Copyright 2023 Joe Porembski
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+SPDX-License-Identifier: BSD-3-Clause
 ------------------------------------------------------------------------------*/
 #pragma once
 
@@ -48,10 +24,19 @@ public:
     DHTType type() const;
 
 private:
-    bool _check() const;
+    bool _checkResponse() const;
+
+    /**
+     * Reads a bit from the sensor's data pin according to the protocol used by DHT sensors.
+     *
+     * @note See https://www.waveshare.com/wiki/DHT22_Temperature-Humidity_Sensor
+     * @return true if the bit is high, false if the bit is low.
+     */
+    bool _getDataBit() const;
+    uint8_t _getDataByte() const;
     void _read();
-    void _reset();
     void _setLED(uint8_t state) const;
+    void _start();
 
     float _humidity;
     float _temperature;

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -2,12 +2,16 @@
 Copyright 2023 Joe Porembski
 SPDX-License-Identifier: BSD-3-Clause
 ------------------------------------------------------------------------------*/
-#include "generated/configuration.hpp"
 
-#include <pico/stdlib.h>
+#include "utilities.hpp"
+
+#include <pico/time.h>
+#include <pico/types.h>
+
+#include <cstdint>
 
 
-int main(int argc, char** argv)
+uint64_t microseconds()
 {
-    return 0;
+    return to_us_since_boot(get_absolute_time());
 }

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -2,12 +2,16 @@
 Copyright 2023 Joe Porembski
 SPDX-License-Identifier: BSD-3-Clause
 ------------------------------------------------------------------------------*/
-#include "generated/configuration.hpp"
-
-#include <pico/stdlib.h>
+#pragma once
 
 
-int main(int argc, char** argv)
-{
-    return 0;
-}
+#include <pico/time.h>
+#include <pico/types.h>
+
+#include <cstdint>
+
+
+/**
+ * @return The microseconds since boot.
+ */
+uint64_t microseconds();


### PR DESCRIPTION
This commit integrates the initial version of the DHT Sensor code based on available
reference code from Waveshare and Raspberry Pi. This integration is provided through
the DHT class, which handles reading from the sensor and provides accessors for humidity
and temperature.

This code also adds a a utility to measure the microseconds since boot.

Closes #3 